### PR TITLE
fix: compile on debian 13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@
 
 KERNEL_MODULE_NAME := marian/snd-marian
 
+# Disable module signing
+CONFIG_MODULE_SIG=n
+
 DBG_LVL_ERROR	:= 1
 DBG_LVL_WARN	:= 2
 DBG_LVL_INFO	:= 3

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,11 @@ PWD := $(shell pwd)
 
 default:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules \
-        EXTRA_CFLAGS="-DDBG_LEVEL=$(DBG_LEVEL)"
+        EXTRA_CFLAGS="-DDBG_LEVEL=$(DBG_LEVEL) -include $(PWD)/snd_printk_compat.h"
 
 install:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules_install \
-        EXTRA_CFLAGS="-DDBG_LEVEL=$(DBG_LEVEL)"
+        EXTRA_CFLAGS="-DDBG_LEVEL=$(DBG_LEVEL) -include $(PWD)/snd_printk_compat.h"
 
 clean:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean

--- a/snd_printk_compat.h
+++ b/snd_printk_compat.h
@@ -1,0 +1,20 @@
+/* ------------------------------------------------------------------
+ *  ALSA compatibility stub for removed snd_printk()
+ *  Only used when building against newer kernels.
+ * ------------------------------------------------------------------ */
+#ifndef SND_PRINTK_COMPAT_H
+#define SND_PRINTK_COMPAT_H
+
+#include <linux/printk.h>
+
+/*
+ * snd_printk(fmt, ...)
+ * Historically a wrapper around printk() that prefixed messages
+ * with source file and line when CONFIG_SND_VERBOSE_PRINTK was set.
+ * For compatibility we just forward to printk() directly.
+ */
+#ifndef snd_printk
+# define snd_printk(fmt, ...) printk(fmt, ##__VA_ARGS__)
+#endif
+
+#endif /* SND_PRINTK_COMPAT_H */

--- a/update.sh
+++ b/update.sh
@@ -3,12 +3,10 @@
 make clean
 clear
 if make -j4; then
-	systemctl --user stop pulseaudio.socket
-	systemctl --user stop pulseaudio.service
+	systemctl --user stop wireplumber pipewire pipewire-pulse
 	sudo rmmod snd-marian
 	sudo insmod marian/snd-marian.ko
-	systemctl --user start pulseaudio.service
-	systemctl --user start pulseaudio.socket
+	systemctl --user start wireplumber pipewire pipewire-pulse
 else
 	echo "Build failed"
 fi


### PR DESCRIPTION
With these changes I can build and load the driver on Debian 13 (trixie):

* `snd_printk` was removed from the kernel. This adds a replacement. **Note:** The `snd_printk_compat.h` was written by ChatGPT 5 so should be reviewed by someone more experienced with kernel C than me.
* Added `CONFIG_MODULE_SIG=n` to the makefile to disable module signing, otherwise the module fails to load in Debian 13
* Changed the `update.sh` script to work with Pipewire

Fixes #2 