### PR TITLE
Fix NULL pointer dereference during module unload

### DIFF
--- a/marian/device_generic.c
+++ b/marian/device_generic.c
@@ -109,14 +109,16 @@ void generic_chip_free(struct generic_chip *chip)
 {
 	if (chip == NULL)
 		return;
-	if (chip->specific_free != NULL)
-		chip->specific_free(chip);
-	if (chip->irq) {
+	/* Free IRQ before tearing down chip->specific to prevent the
+	 * IRQ handler from dereferencing freed/NULL resources (bar1). */
+	if (chip->irq >= 0) {
 		free_irq(chip->irq, chip);
 		pci_disable_msi(chip->pci_dev);
 		chip->irq = -1;
 		PRINT_DEBUG("free_irq\n");
 	}
+	if (chip->specific_free != NULL)
+		chip->specific_free(chip);
 	if (chip->playback_buf.area != NULL)
 		snd_dma_free_pages(&chip->playback_buf);
 	if (chip->capture_buf.area != NULL)

--- a/marian/dma_ng.c
+++ b/marian/dma_ng.c
@@ -68,6 +68,8 @@ int dma_ng_disable_interrupts(struct generic_chip *chip)
 	write_reg32_bar0(chip, ADDR_IRQ_DISABLE_REG,
 		MASK_IRQ_DISABLE_CAPTURE | MASK_IRQ_DISABLE_PLAYBACK);
 	// disable xilinx core interrupts and transport engine
+	if (chip->specific == NULL)
+		return -EINVAL;
 	write_reg32_bar1(chip, ADDR_XILINX_H2C_REG, 0);
 	write_reg32_bar1(chip, ADDR_XILINX_C2H_REG, 0);
 	write_reg32_bar1(chip, ADDR_XILINX_IRQ_ENABLE_REG, 0);


### PR DESCRIPTION
Reorder generic_chip_free() to call free_irq() before chip->specific_free(). The previous ordering allowed the IRQ handler to fire after chip->specific was freed and set to NULL, causing a NULL pointer dereference in dma_ng_disable_interrupts() when accessing bar1 via write_reg32_bar1().

Also add a defensive NULL check on chip->specific in dma_ng_disable_interrupts() and fix the IRQ guard condition from (chip->irq) to (chip->irq >= 0) since irq is initialized to -1.